### PR TITLE
Fix parameter name for 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,7 @@ const paginatedRequest = async (url, method = 'GET', body = '') => {
     }
 
     if (out.meta.next_token) {
-      url.searchParams.set('paginationToken', out.response?.meta.next_token);
+      url.searchParams.set('pagination_token', out.meta.next_token);
     }
 
     const response = await request(url, method, body);


### PR DESCRIPTION
Thank you for your sample project to use Twitter API v2 for bookmarks. I tried to use it and found the probrems that we cannot use paginatedRequest because of following causes, we get always 100 bookmarks if we have more bookmarks.
- Wrong parameter for paginationToken
- `out.response` is undifined value

This PR is fix the parameter and the value. If you do not accept any PR in this sample project, can you close this PR please?.

I refered below document for checking the parameter.
https://developer.twitter.com/en/docs/twitter-api/tweets/bookmarks/api-reference/get-users-id-bookmarks